### PR TITLE
feat: add reusable workflows for addon repos

### DIFF
--- a/.github/scripts/post-pkg-comment.cjs
+++ b/.github/scripts/post-pkg-comment.cjs
@@ -1,0 +1,113 @@
+/**
+ * Post a PR comment with package download links and size comparison.
+ *
+ * This script is sourced from wow-build-tools (not the PR branch) to prevent
+ * PR authors from modifying comment logic that runs with workflow token
+ * permissions.
+ */
+module.exports = async ({
+  github,
+  context,
+  hasStandard = true,
+  hasNoLib = true,
+  noLibUrl,
+  libsUrl,
+  latestReleaseStandardSize,
+  testPkgStandardSize,
+  latestReleaseNoLibSize,
+  testPkgNoLibSize,
+}) => {
+  const commentIdentifier = "### 📦 Packaged ZIP files";
+
+  // Format bytes to human-readable size
+  function formatBytes(bytes) {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + " " + sizes[i];
+  }
+
+  // Calculate size change with handling for first release
+  function getSizeChange(oldSize, newSize) {
+    if (oldSize === 0) {
+      return {
+        emoji: "🆕",
+        text: formatBytes(newSize),
+        detailed: "First release",
+      };
+    }
+    const diff = newSize - oldSize;
+    const percentChange = ((diff / oldSize) * 100).toFixed(1);
+    const emoji = diff > 5120 ? "⚠️" : diff < 0 ? "🟢" : "➡️"; // 5KB threshold for warning
+    const sign = diff > 0 ? "+" : "";
+    return {
+      emoji,
+      text: formatBytes(newSize),
+      detailed: `${formatBytes(oldSize)} ➡️ ${formatBytes(newSize)} (${sign}${percentChange}%)`,
+    };
+  }
+
+  const standardChange = getSizeChange(
+    latestReleaseStandardSize,
+    testPkgStandardSize,
+  );
+  const nolibChange = getSizeChange(latestReleaseNoLibSize, testPkgNoLibSize);
+
+  const hasReleases =
+    latestReleaseStandardSize > 0 || latestReleaseNoLibSize > 0;
+
+  const lastUpdated = new Date().toLocaleString("en-US", {
+    timeZone: "UTC",
+    hour12: true,
+  });
+
+  let commentBody = `${commentIdentifier}\n\n`;
+
+  // If neither package type exists, show an error message
+  if (!hasStandard && !hasNoLib) {
+    commentBody += `⚠️ No package files were generated. Check the workflow logs for errors.\n\n`;
+  } else {
+    commentBody += `| Package | Size | ${hasReleases ? "Change" : "Status"} |\n`;
+    commentBody += `|---------|------|${hasReleases ? "--------" : "--------"}|\n`;
+
+    if (hasStandard) {
+      const label = hasNoLib ? "With Libraries" : "Package";
+      commentBody += `| [${label}](${libsUrl}) | ${standardChange.text} | ${standardChange.emoji} ${standardChange.detailed} |\n`;
+    }
+
+    if (hasNoLib) {
+      commentBody += `| [NoLib](${noLibUrl}) | ${nolibChange.text} | ${nolibChange.emoji} ${nolibChange.detailed} |\n`;
+    }
+
+    commentBody += `\n`;
+  }
+
+  commentBody += `*Last Updated: ${lastUpdated} (UTC)*`;
+
+  const { data: comments } = await github.rest.issues.listComments({
+    issue_number: context.issue.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+  });
+
+  const existingComment = comments.find((comment) =>
+    comment.body.includes(commentIdentifier),
+  );
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      comment_id: existingComment.id,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: commentBody,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: commentBody,
+    });
+  }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+# Reusable workflow: CI pipeline (tests, i18n, semantic-release)
+#
+# Triggered on push to main/release branches. Runs Lua tests, optional i18n
+# translation checks, and semantic-release.
+#
+# Inputs:
+#   addon-name:     Addon directory name (e.g., Endeavoring, RPGLootFeed)
+#   rockspec-name:  Rockspec filename (e.g., endeavoring-1-1.rockspec)
+#   lua-version:    Lua version for tests (e.g., 5.4.4, 5.3.5)
+#   i18n-enabled:   Whether to run i18n translation checks
+#
+# Requires secrets (via `secrets: inherit`):
+#   - GH_PAT (org-level) for semantic-release
+
+name: CI
+
+on:
+  workflow_call:
+    inputs:
+      addon-name:
+        description: Addon directory name (e.g., Endeavoring, RPGLootFeed)
+        required: true
+        type: string
+      rockspec-name:
+        description: Rockspec filename (e.g., endeavoring-1-1.rockspec)
+        required: true
+        type: string
+      lua-version:
+        description: Lua version for tests (e.g., 5.4.4, 5.3.5)
+        required: true
+        type: string
+      i18n-enabled:
+        description: Whether to run i18n translation checks
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  i18n_translations:
+    if: ${{ inputs.i18n-enabled }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Sync uv environment
+        run: uv sync
+
+      - name: Run translation check script
+        run: uv run .scripts/missing_translation_check.py
+
+      - name: Create or Update Issues
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: uv run .scripts/create_or_update_i18n_issues.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run_tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
+        with:
+          luaVersion: ${{ inputs.lua-version }}
+
+      - uses: leafo/gh-actions-luarocks@v4
+        with:
+          luaRocksVersion: 3.11.1
+
+      - name: Install luarock dependencies
+        run: luarocks make --local ${{ inputs.rockspec-name }}
+
+      - name: Run Tests
+        run: make test-ci
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: luacov-html
+          path: luacov-html/
+
+  release:
+    needs: [run_tests, i18n_translations]
+    if: ${{ !cancelled() && needs.run_tests.result == 'success' && (needs.i18n_translations.result == 'success' || needs.i18n_translations.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: npm run semantic-release

--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -1,0 +1,34 @@
+# Reusable workflow: Close stale issues and PRs
+#
+# Marks issues/PRs labeled "awaiting-response" as stale after a period of
+# inactivity, then auto-closes them if still no response.
+#
+# Called by individual addon repos via workflow_call.
+# No inputs needed — all config is standardized org-wide.
+
+name: Close stale issues
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          stale-issue-message: ":robot: This issue has been marked as stale because the repository maintainer(s) have not received a response to the request for more information. If you are still interested in getting this implemented, please provide the requested information within the next 7 days or the issue will be automatically closed. Thank you!"
+          days-before-pr-stale: 30
+          stale-pr-message: ":robot: This pull request has been marked as stale because the repository maintainer(s) have not received a response to their comment(s)/question(s). If you are still interested in moving forward with this pull request, please provide the requested information within the next 14 days or the pull request will be automatically closed. Thank you!"
+          days-before-issue-close: 7
+          close-issue-message: ":robot: This issue was automatically closed because the repository maintainer(s) did not receive a response to the request for more information. If you are still interested in getting this implemented, please feel free to open a new issue with the requested information. Thank you!"
+          days-before-pr-close: 14
+          close-pr-message: ":robot: This pull request was automatically closed because the repository maintainer(s) did not receive a response to their comment(s)/question(s). If you are still interested in moving forward with this pull request, please feel free to open a new pull request with the requested information. Thank you!"
+          only-labels: awaiting-response

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -24,11 +24,11 @@ on:
   workflow_call:
     inputs:
       addon-name:
-        description: "Addon directory name (e.g., Endeavoring, RPGLootFeed)"
+        description: Addon directory name (e.g., Endeavoring, RPGLootFeed)
         required: true
         type: string
       avatar-url:
-        description: "Discord embed avatar image URL"
+        description: Discord embed avatar image URL
         required: true
         type: string
 

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -1,0 +1,136 @@
+# Reusable workflow: Package, distribute, and announce addon releases
+#
+# Triggered by release:published. Packages the addon via wow-build-tools,
+# uploads to addon platforms, and announces on Discord.
+#
+# Distribution links are built dynamically from the addon's .toc file:
+#   - X-Curse-Project-ID → CurseForge link
+#   - X-WoWI-ID → WoWInterface link
+#   - X-Wago-ID → Wago link
+# If a TOC field is missing, the corresponding link is omitted from the
+# Discord announcement.
+#
+# Inputs:
+#   addon-name: The addon directory/name (e.g., "Endeavoring", "RPGLootFeed")
+#   avatar-url:  Discord embed avatar URL
+#
+# Requires secrets (via `secrets: inherit`):
+#   - CF_API_KEY, WOWI_API_TOKEN, WAGO_API_TOKEN (org-level)
+#   - DISCORD_RELEASES_WEBHOOK (repo-level, standardized name)
+
+name: Package and release
+
+on:
+  workflow_call:
+    inputs:
+      addon-name:
+        description: "Addon directory name (e.g., Endeavoring, RPGLootFeed)"
+        required: true
+        type: string
+      avatar-url:
+        description: "Discord embed avatar image URL"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+      WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Package and distribute
+        env:
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
+        with:
+          args: -t ./${{ inputs.addon-name }} -r ./.release
+
+  announce:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v4
+
+      - name: Parse TOC for distribution IDs
+        id: toc
+        run: |
+          TOC_FILE="${{ inputs.addon-name }}/${{ inputs.addon-name }}.toc"
+          if [[ ! -f "$TOC_FILE" ]]; then
+            echo "::warning::TOC file not found: $TOC_FILE"
+            exit 0
+          fi
+
+          # Extract distribution IDs from TOC
+          CURSE_ID=$(grep -oP '^## X-Curse-Project-ID:\s*\K\S+' "$TOC_FILE" || echo "")
+          WOWI_ID=$(grep -oP '^## X-WoWI-ID:\s*\K\S+' "$TOC_FILE" || echo "")
+          WAGO_ID=$(grep -oP '^## X-Wago-ID:\s*\K\S+' "$TOC_FILE" || echo "")
+
+          echo "curse_id=$CURSE_ID" >> $GITHUB_OUTPUT
+          echo "wowi_id=$WOWI_ID" >> $GITHUB_OUTPUT
+          echo "wago_id=$WAGO_ID" >> $GITHUB_OUTPUT
+
+          # Lowercase addon name for URL slugs
+          ADDON_SLUG=$(echo "${{ inputs.addon-name }}" | tr '[:upper:]' '[:lower:]')
+          echo "addon_slug=$ADDON_SLUG" >> $GITHUB_OUTPUT
+
+      - name: Build distribution links
+        id: distro-links
+        run: |
+          ADDON_SLUG="${{ steps.toc.outputs.addon_slug }}"
+          CURSE_ID="${{ steps.toc.outputs.curse_id }}"
+          WOWI_ID="${{ steps.toc.outputs.wowi_id }}"
+          WAGO_ID="${{ steps.toc.outputs.wago_id }}"
+
+          LINKS=""
+          if [[ -n "$CURSE_ID" ]]; then
+            LINKS="${LINKS}* :fire: [CurseForge](https://www.curseforge.com/wow/addons/${ADDON_SLUG})"$'\n'
+          fi
+          if [[ -n "$WOWI_ID" ]]; then
+            LINKS="${LINKS}* :wireless: [WoWInterface](https://www.wowinterface.com/downloads/info${WOWI_ID}-${{ inputs.addon-name }}.html)"$'\n'
+          fi
+          if [[ -n "$WAGO_ID" ]]; then
+            LINKS="${LINKS}* :knot: [Wago](https://addons.wago.io/addons/${ADDON_SLUG})"$'\n'
+          fi
+
+          if [[ -n "$LINKS" ]]; then
+            {
+              echo "links<<LINKS_EOF"
+              echo ""
+              echo "Once approved it will also be available via:"
+              echo "$LINKS"
+              echo "LINKS_EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "links=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Announce release
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645
+        with:
+          webhook-url: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+          username: ${{ inputs.addon-name }} Releases
+          avatar-url: ${{ inputs.avatar-url }}
+          embed-title: "New ${{ inputs.addon-name }} Release: ${{ github.event.release.tag_name || ':tada:' }}"
+          embed-description: |
+            ${{ github.event.release.body || '' }}
+
+            Be the first to download via :octopus: [GitHub](${{ github.event.release.html_url || format('https://github.com/{0}/releases', github.repository) }}) :coin:
+            ${{ steps.distro-links.outputs.links }}
+            > _**Running into issues?** Let me know on [GitHub](https://github.com/${{ github.repository }}/issues) or join the [Discord](https://discord.gg/czRYVWhe33) for the fastest updates and support!_
+          embed-color: 15105570

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,279 @@
+# Reusable workflow: PR checks (tests, translations, packaging, linting)
+#
+# Triggered on pull_request and merge_group events. Runs Lua tests, optional
+# i18n translation checks, test packaging with PR comment, optional trunk
+# linting, and commitlint.
+#
+# Inputs:
+#   addon-name:      Addon directory name (e.g., Endeavoring, RPGLootFeed)
+#   rockspec-name:   Rockspec filename (e.g., endeavoring-1-1.rockspec)
+#   lua-version:     Lua version for tests (e.g., 5.4.4, 5.3.5)
+#   i18n-enabled:    Whether to run i18n translation checks
+#   trunk-enabled:   Whether to run trunk code quality checks
+#
+# Expects in the calling repo:
+#   - .scripts/post-pkg-comment.cjs (for PR package size comment)
+#   - Makefile with test-ci target
+#   - .nvmrc for Node.js version
+#   - commitlint.config.js
+
+name: PR Checks
+
+on:
+  workflow_call:
+    inputs:
+      addon-name:
+        description: Addon directory name (e.g., Endeavoring, RPGLootFeed)
+        required: true
+        type: string
+      rockspec-name:
+        description: Rockspec filename (e.g., endeavoring-1-1.rockspec)
+        required: true
+        type: string
+      lua-version:
+        description: Lua version for tests (e.g., 5.4.4, 5.3.5)
+        required: true
+        type: string
+      i18n-enabled:
+        description: Whether to run i18n translation checks
+        required: false
+        type: boolean
+        default: false
+      trunk-enabled:
+        description: Whether to run trunk code quality checks
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  check_translations:
+    if: ${{ inputs.i18n-enabled }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Sync uv environment
+        run: uv sync
+
+      - name: Run translation check script
+        run: uv run .scripts/missing_translation_check.py
+
+      - name: Check for Hard-coded strings
+        run: uv run .scripts/hardcode_string_check.py
+
+      - name: Run missing locale keys script
+        run: uv run .scripts/check_for_missing_locale_keys.py
+
+  run_tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
+        with:
+          luaVersion: ${{ inputs.lua-version }}
+
+      - uses: leafo/gh-actions-luarocks@v4
+        with:
+          luaRocksVersion: 3.11.1
+
+      - name: Install luarock dependencies
+        run: luarocks make --local ${{ inputs.rockspec-name }}
+
+      - name: Run Tests
+        run: make test-ci
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: luacov-html
+          path: luacov-html/
+
+  test_package:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Fetch Latest Release Assets
+        id: fetch-release-assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if any releases exist
+          if gh release list --limit 1 | grep -q .; then
+            # Try to get nolib size, default to 0 if not found
+            nolib_size=$(gh release view --json assets -q '.assets[] | select(.name | endswith("nolib.zip")) | .size' || echo "0")
+            nolib_size=${nolib_size:-0}
+
+            # Try to get standard size, default to 0 if not found
+            lib_size=$(gh release view --json assets -q '.assets[] | select(.name | endswith(".zip")) | select(.name | contains("-nolib") | not) | .size' || echo "0")
+            lib_size=${lib_size:-0}
+
+            echo "NoLibSize: $nolib_size"
+            echo "LibSize: $lib_size"
+            echo "LATEST_RELEASE_NOLIB_SIZE=$nolib_size" >> $GITHUB_OUTPUT
+            echo "LATEST_RELEASE_LIBS_SIZE=$lib_size" >> $GITHUB_OUTPUT
+          else
+            echo "No releases found, setting sizes to 0"
+            echo "LATEST_RELEASE_NOLIB_SIZE=0" >> $GITHUB_OUTPUT
+            echo "LATEST_RELEASE_LIBS_SIZE=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Package
+        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
+        with:
+          args: -d -t ./${{ inputs.addon-name }} -r ./.release --skipChangelog -n {package-name}-pr${{github.event.number}}-{nolib}{classic}
+
+      - name: Capture Filenames
+        id: capture-filenames
+        run: |
+          # Check for nolib build
+          if ls .release/*-nolib.zip 1> /dev/null 2>&1; then
+            FILE1=$(ls .release/*-nolib.zip | head -n1)
+            echo "NOLIBZIP=$FILE1" >> $GITHUB_OUTPUT
+            echo "TEST_NOLIB_SIZE=$(stat -c%s "$FILE1")" >> $GITHUB_OUTPUT
+            echo "HAS_NOLIB=true" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_NOLIB=false" >> $GITHUB_OUTPUT
+            echo "TEST_NOLIB_SIZE=0" >> $GITHUB_OUTPUT
+          fi
+
+          # Check for standard build (with or without libs)
+          if ls .release/*.zip 2>/dev/null | grep -v 'nolib' 1> /dev/null 2>&1; then
+            FILE2=$(ls .release/*.zip | grep -v 'nolib' | head -n1)
+            echo "ZIP=$FILE2" >> $GITHUB_OUTPUT
+            echo "TEST_LIBS_SIZE=$(stat -c%s "$FILE2")" >> $GITHUB_OUTPUT
+            echo "HAS_STANDARD=true" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_STANDARD=false" >> $GITHUB_OUTPUT
+            echo "TEST_LIBS_SIZE=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload Standard Package
+        if: steps.capture-filenames.outputs.HAS_STANDARD == 'true'
+        uses: actions/upload-artifact@v4
+        id: upload-zips-standard
+        with:
+          name: pr-pkg
+          path: ${{ steps.capture-filenames.outputs.ZIP }}
+
+      - name: Upload NoLib Package
+        if: steps.capture-filenames.outputs.HAS_NOLIB == 'true'
+        uses: actions/upload-artifact@v4
+        id: upload-zips-nolib
+        with:
+          name: pr-pkg-nolib
+          path: ${{ steps.capture-filenames.outputs.NOLIBZIP }}
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.scripts/post-pkg-comment.cjs');
+            await script({
+              github,
+              context,
+              hasStandard: ${{ steps.capture-filenames.outputs.HAS_STANDARD == 'true' }},
+              hasNoLib: ${{ steps.capture-filenames.outputs.HAS_NOLIB == 'true' }},
+              libsUrl: "${{ steps.upload-zips-standard.outputs.artifact-url || '' }}",
+              noLibUrl: "${{ steps.upload-zips-nolib.outputs.artifact-url || '' }}",
+              latestReleaseStandardSize: ${{ steps.fetch-release-assets.outputs.LATEST_RELEASE_LIBS_SIZE }},
+              testPkgStandardSize: ${{ steps.capture-filenames.outputs.TEST_LIBS_SIZE }},
+              latestReleaseNoLibSize: ${{ steps.fetch-release-assets.outputs.LATEST_RELEASE_NOLIB_SIZE }},
+              testPkgNoLibSize: ${{ steps.capture-filenames.outputs.TEST_NOLIB_SIZE }},
+            });
+
+  trunk-check:
+    if: ${{ inputs.trunk-enabled }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Trunk Cache
+        uses: actions/cache@v4
+        with:
+          key: trunk-cache-${{ hashFiles('**/trunk.yaml') }}
+          path: ~/.cache/trunk
+
+      - name: Trunk Code Quality
+        uses: trunk-io/trunk-action@v1
+
+  commitlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install commitlint
+        run: |
+          npm install @commitlint/config-conventional @commitlint/cli
+
+      - name: Run commitlint (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "${TITLE}" | npx commitlint
+
+      - name: Run commitlint (Merge Group)
+        if: ${{ github.event_name == 'merge_group' }}
+        run: npx commitlint --last
+
+  all_pr_checks:
+    name: Passing PR Checks
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      [check_translations, run_tests, test_package, trunk-check, commitlint]
+    steps:
+      - name: Export needs results as JSON
+        id: export-needs
+        run: echo '${{ toJSON(needs) }}' > needs.json
+
+      - name: Check if all jobs passed or were skipped
+        run: |
+          needs=$(cat needs.json)
+          for job in $(echo "$needs" | jq -r 'keys[]'); do
+            result=$(echo "$needs" | jq -r ".\"$job\".result")
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "Job $job failed."
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped."
+        shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -188,11 +188,19 @@ jobs:
           name: pr-pkg-nolib
           path: ${{ steps.capture-filenames.outputs.NOLIBZIP }}
 
+      - name: Checkout wow-build-tools scripts
+        uses: actions/checkout@v4
+        with:
+          repository: McTalian-WoW-Addons/wow-build-tools
+          ref: v1-beta
+          sparse-checkout: .github/scripts
+          path: .wbt
+
       - name: Post PR comment
         uses: actions/github-script@v7
         with:
           script: |
-            const script = require('./.scripts/post-pkg-comment.cjs');
+            const script = require('./.wbt/.github/scripts/post-pkg-comment.cjs');
             await script({
               github,
               context,

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -1,0 +1,76 @@
+# Reusable workflow: Update TOC Interface version(s)
+#
+# Checks for new WoW interface versions daily, updates the addon's .toc file,
+# and creates a PR with the appropriate commit type (toc: for additions,
+# chore: for removals).
+#
+# Inputs:
+#   addon-name: The addon directory/name (e.g., "Endeavoring", "RPGLootFeed")
+#   pr-body:    The PR body markdown (checklist of test requirements)
+#
+# Requires: GH_PAT secret (passed via `secrets: inherit`)
+
+name: Update TOC Interface version(s)
+
+on:
+  workflow_call:
+    inputs:
+      addon-name:
+        description: "Addon directory name (e.g., Endeavoring, RPGLootFeed)"
+        required: true
+        type: string
+      pr-body:
+        description: "PR body markdown with test checklist"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v4
+
+      - name: Update TOC Interface version
+        uses: McTalian-WoW-Addons/wow-build-tools/toc/update@v1-beta
+        with:
+          args: -a ${{ inputs.addon-name }} -b -p
+
+      - name: Detect change type
+        id: change-type
+        run: |
+          # Extract old and new interface versions from git diff
+          OLD_VERSIONS=$(git diff ${{ inputs.addon-name }}/${{ inputs.addon-name }}.toc | grep '^-## Interface:' | sed 's/^-## Interface: //' || echo "")
+          NEW_VERSIONS=$(git diff ${{ inputs.addon-name }}/${{ inputs.addon-name }}.toc | grep '^+## Interface:' | sed 's/^+## Interface: //' || echo "")
+
+          # Count versions in old and new
+          OLD_COUNT=$(echo "$OLD_VERSIONS" | grep -o ',' | wc -l || echo 0)
+          NEW_COUNT=$(echo "$NEW_VERSIONS" | grep -o ',' | wc -l || echo 0)
+
+          # Add 1 to counts since comma count = version count - 1
+          OLD_COUNT=$((OLD_COUNT + 1))
+          NEW_COUNT=$((NEW_COUNT + 1))
+
+          if [ "$NEW_COUNT" -gt "$OLD_COUNT" ]; then
+            echo "pr_title=toc: bump versions, please submit any bugs" >> $GITHUB_OUTPUT
+            echo "commit_message=toc: bump versions, please submit any bugs" >> $GITHUB_OUTPUT
+            echo "Detected version additions (toc commit): $OLD_COUNT -> $NEW_COUNT versions"
+          else
+            echo "pr_title=chore: remove old interface versions" >> $GITHUB_OUTPUT
+            echo "commit_message=chore: remove old interface versions" >> $GITHUB_OUTPUT
+            echo "Detected only version removals or no change (chore commit): $OLD_COUNT -> $NEW_COUNT versions"
+          fi
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GH_PAT }}
+          title: ${{ steps.change-type.outputs.pr_title }}
+          body: ${{ inputs.pr-body }}
+          commit-message: ${{ steps.change-type.outputs.commit_message }}
+          branch: interface-version
+          delete-branch: true

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -16,11 +16,11 @@ on:
   workflow_call:
     inputs:
       addon-name:
-        description: "Addon directory name (e.g., Endeavoring, RPGLootFeed)"
+        description: Addon directory name (e.g., Endeavoring, RPGLootFeed)
         required: true
         type: string
       pr-body:
-        description: "PR body markdown with test checklist"
+        description: PR body markdown with test checklist
         required: true
         type: string
 

--- a/docs/org-migration-plan.md
+++ b/docs/org-migration-plan.md
@@ -40,8 +40,10 @@ These are inherently per-addon and stay at the repo level:
 
 | Secret                     | Repo        | Purpose                       |
 | -------------------------- | ----------- | ----------------------------- |
-| `DISCO_WH_NDVRNG_RELEASES` | Endeavoring | Discord release announcements |
-| `DISCO_WH_RLF_RELEASES`    | RPGLootFeed | Discord release announcements |
+| `DISCORD_RELEASES_WEBHOOK` | Endeavoring | Discord release announcements |
+| `DISCORD_RELEASES_WEBHOOK` | RPGLootFeed | Discord release announcements |
+
+> **Note:** Originally named `DISCO_WH_NDVRNG_RELEASES` and `DISCO_WH_RLF_RELEASES`. Renamed to standardized `DISCORD_RELEASES_WEBHOOK` during Phase 4 reusable workflow work (March 2, 2026).
 
 ### 1c. Create Org `.github` Repo (Optional, Low Priority)
 
@@ -134,17 +136,21 @@ Transfer `wow-build-tools` first since the addons reference it:
 
 ### Progress
 
-- [ ] Endeavoring: All references updated
-- [ ] RPGLootFeed: All references updated
-- [ ] wow-build-tools: All references updated
+- [x] Endeavoring: All references updated
+- [x] RPGLootFeed: All references updated
+- [x] wow-build-tools: All references updated
 
 ---
 
 ## Phase 4: Create Reusable Workflows
 
 > Convert duplicated workflows into parameterized [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) in `wow-build-tools`.
+>
+> **Decision history:** Initially placed in `.github` org repo during Session 2 (March 2). Later decided to move to `wow-build-tools` for better alignment with Phase 6 scaffolding (`wow-build-tools init`) and to enable external addon developers to leverage the same workflows. Callers reference `McTalian-WoW-Addons/wow-build-tools/.github/workflows/<workflow>.yml@v1-beta`.
+>
+> **Next session:** Move existing workflows from `.github` to `wow-build-tools`, update caller references in both addon PRs (Endeavoring #15, RPGLootFeed #528).
 
-### 4a. `cleanup-stale-issues.yml` — Zero Inputs
+### 4a. `cleanup-stale-issues.yml` — Zero Inputs ✅
 
 **Effort:** ~30 min | **Priority:** First — proves the pattern
 
@@ -152,38 +158,44 @@ Transfer `wow-build-tools` first since the addons reference it:
 
 ```yaml
 # Caller workflow in each addon repo (entire file):
+name: Close stale issues
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: 30 1 * * *
+permissions: {}
 jobs:
-  cleanup:
+  stale:
     uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/cleanup-stale-issues.yml@v1-beta
 ```
 
-- [ ] Create reusable workflow in wow-build-tools
-- [ ] Convert Endeavoring caller
-- [ ] Convert RPGLootFeed caller
-- [ ] Verify both repos' stale issue cleanup works
+- [x] Create reusable workflow _(currently in `.github`, needs move to `wow-build-tools`)_
+- [x] Convert Endeavoring caller _(needs ref update after move)_
+- [x] Convert RPGLootFeed caller _(needs ref update after move)_
+- [ ] Move workflow from `.github` to `wow-build-tools` and update caller refs
 
-### 4b. `package-and-distribute.yml`
+### 4b. `package-and-distribute.yml` ✅
 
 **Effort:** ~45 min | **Priority:** High
 
 **Inputs:**
 
-- `addon-name` — used for naming in Discord messages
-- `toc-dir` — e.g., `./Endeavoring` or `./RPGLootFeed`
-- `release-dir` — e.g., `./.release`
-- `discord-avatar-url` — addon logo URL
-- `curseforge-url`, `wowi-url`, `wago-url` — distribution platform links
-- `discord-webhook-secret-name` — name of the Discord webhook secret (repo-level)
+- `addon-name` — addon directory name
+- `avatar-url` — Discord embed avatar image URL
 
-**Secrets:** `secrets: inherit` from caller (pulls org + repo secrets)
+**Dynamic from TOC file:**
 
-- [ ] Create reusable workflow in wow-build-tools
-- [ ] Convert Endeavoring caller
-- [ ] Convert RPGLootFeed caller
-- [ ] Test with a release on both repos
+- `X-Curse-Project-ID` → CurseForge link (slug = lowercased addon name)
+- `X-WoWI-ID` → WoWInterface link
+- `X-Wago-ID` → Wago link
+- Missing IDs → that distribution link is omitted from Discord announcement
+
+**Secrets:** `secrets: inherit` from caller (pulls org + repo secrets). Discord webhook standardized to `DISCORD_RELEASES_WEBHOOK` (repo-level, same name in every repo).
+
+- [x] Standardize Discord webhook secret names across repos
+- [x] Create reusable workflow _(currently in `.github`, needs move to `wow-build-tools`)_
+- [x] Convert Endeavoring caller _(needs ref update after move)_
+- [x] Convert RPGLootFeed caller _(needs ref update after move)_
+- [ ] Move workflow from `.github` to `wow-build-tools` and update caller refs
 
 ### 4c. `ci.yml` (replaces `main.yml`)
 
@@ -197,7 +209,7 @@ jobs:
 - `has-i18n` (boolean) — controls whether i18n translation job runs
 - `spec-dir` — e.g., `Endeavoring_spec` or `RPGLootFeed_spec`
 
-- [ ] Create reusable workflow in wow-build-tools
+- [ ] Create reusable workflow in `wow-build-tools`
 - [ ] Convert Endeavoring caller
 - [ ] Convert RPGLootFeed caller
 - [ ] Verify tests + semantic-release work on both repos
@@ -215,25 +227,27 @@ jobs:
 **Note:** `post-pkg-comment.cjs` should be consolidated first (see Phase 5) or embedded into the reusable workflow.
 
 - [ ] Consolidate `post-pkg-comment.cjs` (see Phase 5)
-- [ ] Create reusable workflow in wow-build-tools
+- [ ] Create reusable workflow in `wow-build-tools`
 - [ ] Convert Endeavoring caller
 - [ ] Convert RPGLootFeed caller
 - [ ] Verify PR checks work on both repos
 
-### 4e. `toc-updater.yml`
+### 4e. `toc-updater.yml` ✅
 
 **Effort:** ~45 min | **Priority:** Medium
 
 **Inputs:**
 
 - `addon-name`
-- `pr-body` — PR description template (differs by addon due to flavor support / extra steps)
-- `extra-pre-pr-steps` — optional, for RPGLootFeed's hidden currency generation
+- `pr-body` — PR description template (differs by addon due to flavor support)
 
-- [ ] Create reusable workflow in wow-build-tools
-- [ ] Convert Endeavoring caller
-- [ ] Convert RPGLootFeed caller
-- [ ] Verify TOC update PRs are created correctly
+**Design decision:** RPGLootFeed's hidden currency generation was split into a separate `hidden-currencies.yml` workflow (runs weekly on Monday 2pm UTC, creates its own PR branch). This keeps the reusable toc-updater clean and generic.
+
+- [x] Create reusable workflow _(currently in `.github`, needs move to `wow-build-tools`)_
+- [x] Convert Endeavoring caller _(needs ref update after move)_
+- [x] Convert RPGLootFeed caller _(needs ref update after move)_
+- [x] Create separate `hidden-currencies.yml` for RPGLootFeed
+- [ ] Move workflow from `.github` to `wow-build-tools` and update caller refs
 
 ---
 
@@ -315,14 +329,15 @@ wow-build-tools init --name MyAddon --flavors retail,classic --platforms cursefo
 
 | Phase                                        | Effort     | Status         |
 | -------------------------------------------- | ---------- | -------------- |
-| **Phase 1**: Org secrets                     | ~10 min    | ⬜ Not started |
-| **Phase 2**: Transfer repos                  | ~15 min    | ⬜ Not started |
-| **Phase 3**: Update references               | ~30 min    | ⬜ Not started |
-| **Phase 4a**: Stale issues reusable workflow | ~30 min    | ⬜ Not started |
-| **Phase 4b**: Package & distribute reusable  | ~45 min    | ⬜ Not started |
+| **Phase 1**: Org secrets                     | ~10 min    | ✅ Complete    |
+| **Phase 2**: Transfer repos                  | ~15 min    | ✅ Complete    |
+| **Phase 3**: Update references               | ~30 min    | ✅ Complete    |
+| **Phase 3.5**: Standardize rulesets          | ~1 hour    | ✅ Complete    |
+| **Phase 4a**: Stale issues reusable workflow | ~30 min    | ⚠️ Move to WBT |
+| **Phase 4b**: Package & distribute reusable  | ~45 min    | ⚠️ Move to WBT |
 | **Phase 4c**: CI reusable workflow           | ~1 hour    | ⬜ Not started |
 | **Phase 4d**: PR checks reusable workflow    | ~1.5 hours | ⬜ Not started |
-| **Phase 4e**: TOC updater reusable workflow  | ~45 min    | ⬜ Not started |
+| **Phase 4e**: TOC updater reusable workflow  | ~45 min    | ⚠️ Move to WBT |
 | **Phase 5**: Script/config consolidation     | ~1 hour    | ⬜ Not started |
 | **Phase 6**: `init` command                  | ~Half day  | ⬜ Future      |
 
@@ -339,8 +354,9 @@ wow-build-tools init --name MyAddon --flavors retail,classic --platforms cursefo
 | `WAGO_API_TOKEN`           |     ✅      |     ✅      |        —        |    ✅ Yes     |
 | `GH_PAT`                   |     ✅      |     ✅      |       ✅        |    ✅ Yes     |
 | `GITHUB_TOKEN`             |  ✅ (auto)  |  ✅ (auto)  |        —        | Auto-provided |
-| `DISCO_WH_NDVRNG_RELEASES` |     ✅      |      —      |        —        | ❌ Repo-level |
-| `DISCO_WH_RLF_RELEASES`    |      —      |     ✅      |        —        | ❌ Repo-level |
+| `DISCORD_RELEASES_WEBHOOK` |     ✅      |     ✅      |        —        | ❌ Repo-level |
+
+> **Note:** `DISCO_WH_NDVRNG_RELEASES` and `DISCO_WH_RLF_RELEASES` were renamed to `DISCORD_RELEASES_WEBHOOK` during Phase 4 (March 2, 2026).
 
 ### Variables
 

--- a/docs/org-migration-session-summary.md
+++ b/docs/org-migration-session-summary.md
@@ -1,0 +1,200 @@
+# Org Migration Session Summary
+
+**Session Date:** February 28 – March 2, 2026 (Session 2: March 2)
+**Purpose:** Migrate `Endeavoring`, `RPGLootFeed`, and `wow-build-tools` from `McTalian` personal account to `McTalian-WoW-Addons` GitHub organization.
+
+---
+
+## What Was Accomplished
+
+### Phase 1: Pre-Transfer Preparation ✅
+
+- **Org-level secrets configured:** `CF_API_KEY`, `WOWI_API_TOKEN`, `WAGO_API_TOKEN`, `GH_PAT` — all set at org level, scoped to all repos.
+- **Repo-level secrets identified:** `DISCO_WH_NDVRNG_RELEASES` (Endeavoring) and `DISCO_WH_RLF_RELEASES` (RPGLootFeed) stay per-repo. _(Later renamed to `DISCORD_RELEASES_WEBHOOK` in both repos — see Phase 4.)_
+- **`.github` org repo created** (public) with org profile README.
+
+### Phase 2: Repo Transfers ✅
+
+- **New fine-grained PAT** created with `McTalian-WoW-Addons` as resource owner (old PAT still active, should be retired after full verification).
+- **All 3 repos transferred** in order: `wow-build-tools` → `Endeavoring` → `RPGLootFeed`.
+- **Post-transfer for each repo:**
+  - Local git remote updated
+  - Repo-level secrets deleted (they override org-level secrets with same name — learned the hard way)
+  - Branch protection bypass lists re-added as org owners/admins (bypass lists do NOT transfer)
+- **Remaining:** Verify workflows run with org-level secrets on Endeavoring and RPGLootFeed (will happen organically with next release/PR).
+
+### Phase 3: Update Hardcoded References — Nearly Complete
+
+Three separate branches created with reference updates. Status per repo:
+
+#### Endeavoring
+
+- **Branch `chore/update-org-references`:** Merged via PR #12.
+- **Branch `update-more-references`:** Currently on this branch (1 commit ahead of main). Contains additional missed references:
+  - `Endeavoring.toc` — X-Website URL
+  - `endeavoring-1-1.rockspec` — source URL
+  - `package.json` — repository URL (semantic-release uses this!)
+- **PR:** Merged.
+
+#### RPGLootFeed
+
+- **Branch `chore/update-org-references`:** PR #527 open.
+- Contains 3 commits (original update + user's additional fixes).
+- **Files changed (28):** workflows, README.md, README.BB, About.lua, 13 locale files, prompts, docs, PR template, `.scripts/missing_translation_check.py`, `RPGLootFeed.toc`, `package.json`, `rpglootfeed-1-1.rockspec`.
+- **Status:** PR is open, needs merge.
+
+#### wow-build-tools
+
+- **Branch `chore/update-org-references`:** 1 commit ahead of beta.
+- **Files changed (7):** `release-published.yml`, `README.md`, `updatebin.go` (repo const), `toc/check/README.md`, `toc/update/README.md`, plus new `docs/org-migration-plan.md` and `future-improvements.md`.
+- **PR:** Merged.
+- **Note:** Go module path (`github.com/McTalian/wow-build-tools`) in `go.mod` and all Go imports intentionally NOT updated yet — works via GitHub redirect. Can update later as a separate change.
+
+### Phase 3.5: Standardize Repo Rulesets ✅
+
+Org-level rulesets require GitHub Team (paid plan, $4/user/month additive to individual Pro/Copilot). Instead, standardized repo-level rulesets across all three repos via API.
+
+- **Standardized config applied to all three repos:**
+  - Branches: `~DEFAULT_BRANCH`, `v*`, `alpha`, `beta`, `main`
+  - Rules: deletion, non_fast_forward, update (block force push), creation (block new protected-pattern branches)
+  - PR: 1 approval required, squash + rebase allowed
+  - Status checks: "Passing PR Checks" (skip on create)
+  - Copilot code review: enabled
+  - Bypass: OrganizationAdmin (always) — unblocks solo maintainer workflow
+- **Reusable tooling created in `.github` org repo:**
+  - `rulesets/default.json` — canonical ruleset definition (single source of truth)
+  - `scripts/apply-ruleset.sh` — CLI to apply to one repo or all repos (`--all`), with `--dry-run` support
+  - Detects existing rulesets (updates) vs missing (creates)
+- **Auth note:** `gh auth refresh -s admin:org` was needed for ruleset API access
+
+---
+
+## Lessons Learned / Gotchas
+
+1. **Repo-level secrets override org-level secrets with the same name.** After transferring, the old repo-level `GH_PAT` shadowed the new org-level one. Fix: delete repo-level secrets that are now org-level.
+
+2. **Branch protection bypass lists don't transfer.** The personal account admin bypass didn't carry over. Fix: re-add as org owners/admins.
+
+3. **`package.json` `repository.url` matters for semantic-release.** Semantic-release uses it to determine the GitHub repo for creating releases. When you drop `package.json` per addon (Phase 5), the `repositoryUrl` in `.releaserc.json` or CI-detected repo URL will be the fallback.
+
+4. **More reference locations than expected.** Beyond workflows, references existed in:
+   - `.toc` files (`X-Website`)
+   - Rockspec files (`source.url`)
+   - `package.json` (`repository.url`)
+   - Locale files (user-facing strings with GitHub links)
+   - `README.BB` (BBCode version of README for WoWInterface)
+   - Python scripts (`.scripts/missing_translation_check.py` output text)
+   - Go const in `updatebin.go` (self-update target repo)
+
+5. **GitHub redirects are indefinite** but break if someone creates a repo with the old name under the old owner. Treat them as a convenience bridge, not a permanent solution.
+
+6. **Org-level rulesets require GitHub Team plan.** Free org plans only support repo-level rulesets. Workaround: maintain canonical config in `.github` org repo and apply via script.
+
+7. **Reusable workflows should live in `wow-build-tools`, not `.github`.** Initially placed in `.github` org repo during Session 2. Later reconsidered: `wow-build-tools` is better because (a) external addon devs already use WBT and can leverage the same workflows, (b) WBT has versioned tags (`@v1-beta`) for stable pinning vs `.github`'s `@main`, and (c) Phase 6 scaffolding (`wow-build-tools init`) can generate callers that reference the same repo. **Action for next session:** move the 3 completed workflows from `.github` to `wow-build-tools` and update caller refs.
+
+8. **`secrets: inherit` covers both org-level and repo-level secrets.** No need for explicit secret inputs as long as secret names are standardized across repos. This enabled standardizing Discord webhook secrets to `DISCORD_RELEASES_WEBHOOK` (same name, different values per repo).
+
+9. **TOC files are a rich source of addon metadata.** `X-Curse-Project-ID`, `X-WoWI-ID`, `X-Wago-ID` can be parsed at workflow runtime to dynamically build distribution links, reducing inputs and preventing stale URLs.
+
+10. **`gh pr edit` fails with a GraphQL deprecation warning about Projects Classic.** Workaround: use the REST API directly via `gh api -X PATCH repos/{owner}/{repo}/pulls/{number}`.
+
+---
+
+## What Remains
+
+### Phase 3: Finish Reference Updates ✅
+
+- [x] Open PR for Endeavoring `update-more-references` branch and merge
+- [x] Merge RPGLootFeed PR #527
+- [x] Open PR for wow-build-tools `chore/update-org-references` branch and merge
+- [ ] Retire old personal PAT (Phase 2, step 2a.3 — after verifying all workflows and migrating remaining addons)
+
+### Phase 3.5: Standardize Repo Rulesets (Remaining) ✅
+
+- [x] Audit existing rulesets across all 3 repos
+- [x] Design standardized config
+- [x] Apply via API to RPGLootFeed, Endeavoring, wow-build-tools
+- [x] Create reusable script + canonical JSON in `.github` org repo
+- [x] Push to `.github` main
+
+### Phase 4: Create Reusable Workflows — Mostly Complete
+
+Reusable workflows initially placed in `McTalian-WoW-Addons/.github/.github/workflows/`. Pivoted to `wow-build-tools` for external adoption, versioned tags, and Phase 6 alignment.
+
+#### Completed (Session 2, March 2 + Session 3, March 2 PM)
+
+1. **`cleanup-stale-issues.yml`** ✅ — Zero inputs, identical config. Proved the pattern.
+2. **`toc-updater.yml`** ✅ — Inputs: `addon-name`, `pr-body`. RPGLootFeed's hidden currencies steps split into a separate `hidden-currencies.yml` workflow (weekly Monday 2pm UTC).
+3. **`package-and-distribute.yml`** ✅ — Inputs: `addon-name`, `avatar-url`. Distribution links (CurseForge, WoWInterface, Wago) parsed dynamically from the addon's `.toc` file (`X-Curse-Project-ID`, `X-WoWI-ID`, `X-Wago-ID`). Missing IDs → that link is omitted from the Discord announcement.
+   - **Discord webhook secrets standardized:** `DISCO_WH_NDVRNG_RELEASES` → `DISCORD_RELEASES_WEBHOOK` (Endeavoring), `DISCO_WH_RLF_RELEASES` → `DISCORD_RELEASES_WEBHOOK` (RPGLootFeed). Same name, different values per repo.
+
+#### Session 3: Workflow Move Complete ✅
+
+1. ✅ Moved 3 workflows from `.github/.github/workflows/` → `wow-build-tools/.github/workflows/` (`feat/reusable-workflows` branch)
+2. ✅ Updated caller refs in both addon PRs: `.../.github/.github/workflows/...@main` → `.../wow-build-tools/.github/workflows/...@v1-beta`
+3. ✅ Cleaned up `.github` repo (removed moved workflow files from main)
+
+**Merge order:** wow-build-tools `feat/reusable-workflows` → beta → update `v1-beta` tag → merge addon PRs
+
+**PRs open (both repos, same branch `chore/reusable-stale-workflow`):**
+
+- [Endeavoring PR #15](https://github.com/McTalian-WoW-Addons/Endeavoring/pull/15) — stale + toc-updater + package-and-distribute (caller refs updated ✅)
+- [RPGLootFeed PR #528](https://github.com/McTalian-WoW-Addons/RPGLootFeed/pull/528) — stale + toc-updater + hidden-currencies + package-and-distribute (caller refs updated ✅)
+
+**wow-build-tools PR:** `feat/reusable-workflows` — needs merge to beta, then update `v1-beta` tag
+
+#### Remaining
+
+4. `ci.yml` / `main.yml` (parameterized with addon name, Lua version, i18n toggle)
+5. `pr-checks.yml` (parameterized, needs `post-pkg-comment.cjs` consolidation first)
+
+### Phase 5: Consolidate Scripts & Config
+
+Not started. Key items:
+
+- **`post-pkg-comment.cjs`** — Endeavoring version is more robust; backport to RPGLootFeed, then move to wow-build-tools
+- **Identical files to share:** `commitlint.config.js`, `.releaserc.json`
+- **Align `.nvmrc`** (`v24` vs `24.10.0`)
+- **Align Lua version** (Endeavoring CI: 5.4, RPGLootFeed CI: 5.3 — both rockspecs say `>= 5.3`)
+
+### Phase 6: `wow-build-tools init` Command
+
+Future. Scaffolding command for new addons.
+
+### Future Addon Migrations
+
+~3-5 more addons to migrate to the org. Keep in mind:
+
+- When `package.json` is dropped (Phase 5), semantic-release will need `repositoryUrl` in `.releaserc.json` or will use CI-detected URL.
+- The same reference update sweep will be needed for each addon.
+
+---
+
+## Key Files & Locations
+
+| Resource                              | Location                                                                                                                           |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Migration plan** (with checkboxes)  | `wow-build-tools/docs/org-migration-plan.md`                                                                                       |
+| **This session summary**              | `wow-build-tools/docs/org-migration-session-summary.md`                                                                            |
+| **Endeavoring pending branch**        | Merged                                                                                                                             |
+| **RPGLootFeed reference PR**          | [PR #527](https://github.com/McTalian-WoW-Addons/RPGLootFeed/pull/527) — Merged                                                    |
+| **wow-build-tools pending branch**    | Merged                                                                                                                             |
+| **Ruleset canonical config**          | `.github/rulesets/default.json`                                                                                                    |
+| **Ruleset apply script**              | `.github/scripts/apply-ruleset.sh`                                                                                                 |
+| **Reusable workflows**                | `wow-build-tools/.github/workflows/` (on `feat/reusable-workflows` branch, pending merge to beta)                                  |
+| **Endeavoring reusable workflows PR** | [PR #15](https://github.com/McTalian-WoW-Addons/Endeavoring/pull/15) on `chore/reusable-stale-workflow` — caller refs updated ✅   |
+| **RPGLootFeed reusable workflows PR** | [PR #528](https://github.com/McTalian-WoW-Addons/RPGLootFeed/pull/528) on `chore/reusable-stale-workflow` — caller refs updated ✅ |
+
+---
+
+## Reference: Files Intentionally Skipped
+
+These were intentionally not updated during the reference sweep:
+
+| Category                                                             | Why                                                               |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Go module path + imports (`github.com/McTalian/wow-build-tools/...`) | Works via redirect; planned for later (large scope, all Go files) |
+| `.release/` directories                                              | Build outputs, regenerated on next build                          |
+| `.scripts/.output/` markdown reports                                 | Generated by Python i18n scripts                                  |
+| `org-migration-plan.md` reference table                              | Historical documentation showing old values                       |
+| "McTalian" as a person/BattleTag in prose                            | Not a repo reference (e.g., sync-protocol.md examples, glossary)  |

--- a/docs/org-migration-session-summary.md
+++ b/docs/org-migration-session-summary.md
@@ -117,7 +117,7 @@ Org-level rulesets require GitHub Team (paid plan, $4/user/month additive to ind
 - [x] Create reusable script + canonical JSON in `.github` org repo
 - [x] Push to `.github` main
 
-### Phase 4: Create Reusable Workflows — Mostly Complete
+### Phase 4: Create Reusable Workflows ✅
 
 Reusable workflows initially placed in `McTalian-WoW-Addons/.github/.github/workflows/`. Pivoted to `wow-build-tools` for external adoption, versioned tags, and Phase 6 alignment.
 
@@ -127,32 +127,33 @@ Reusable workflows initially placed in `McTalian-WoW-Addons/.github/.github/work
 2. **`toc-updater.yml`** ✅ — Inputs: `addon-name`, `pr-body`. RPGLootFeed's hidden currencies steps split into a separate `hidden-currencies.yml` workflow (weekly Monday 2pm UTC).
 3. **`package-and-distribute.yml`** ✅ — Inputs: `addon-name`, `avatar-url`. Distribution links (CurseForge, WoWInterface, Wago) parsed dynamically from the addon's `.toc` file (`X-Curse-Project-ID`, `X-WoWI-ID`, `X-Wago-ID`). Missing IDs → that link is omitted from the Discord announcement.
    - **Discord webhook secrets standardized:** `DISCO_WH_NDVRNG_RELEASES` → `DISCORD_RELEASES_WEBHOOK` (Endeavoring), `DISCO_WH_RLF_RELEASES` → `DISCORD_RELEASES_WEBHOOK` (RPGLootFeed). Same name, different values per repo.
+4. **`ci.yml`** ✅ — Inputs: `addon-name`, `rockspec-name`, `lua-version`, `i18n-enabled`. Runs tests, optional i18n checks, semantic-release. Conditional release job handles skipped i18n gracefully.
+5. **`pr-checks.yml`** ✅ — Inputs: `addon-name`, `rockspec-name`, `lua-version`, `i18n-enabled`, `trunk-enabled`. Full PR pipeline: tests, optional translations, test packaging with PR comment, optional trunk linting, commitlint, and gate job.
+   - **`post-pkg-comment.cjs` consolidated:** Backported Endeavoring's robust version to RPGLootFeed (handles missing releases, missing package types, human-readable byte formatting, table format).
 
-#### Session 3: Workflow Move Complete ✅
+#### Session 3: Workflow Move + CI/PR Checks Complete ✅
 
 1. ✅ Moved 3 workflows from `.github/.github/workflows/` → `wow-build-tools/.github/workflows/` (`feat/reusable-workflows` branch)
 2. ✅ Updated caller refs in both addon PRs: `.../.github/.github/workflows/...@main` → `.../wow-build-tools/.github/workflows/...@v1-beta`
 3. ✅ Cleaned up `.github` repo (removed moved workflow files from main)
+4. ✅ Created `ci.yml` and `pr-checks.yml` reusable workflows in wow-build-tools
+5. ✅ Updated both addon repos' `main.yml` and `pr-checks.yml` to use reusable callers
+6. ✅ Backported robust `post-pkg-comment.cjs` to RPGLootFeed
 
 **Merge order:** wow-build-tools `feat/reusable-workflows` → beta → update `v1-beta` tag → merge addon PRs
 
 **PRs open (both repos, same branch `chore/reusable-stale-workflow`):**
 
-- [Endeavoring PR #15](https://github.com/McTalian-WoW-Addons/Endeavoring/pull/15) — stale + toc-updater + package-and-distribute (caller refs updated ✅)
-- [RPGLootFeed PR #528](https://github.com/McTalian-WoW-Addons/RPGLootFeed/pull/528) — stale + toc-updater + hidden-currencies + package-and-distribute (caller refs updated ✅)
+- [Endeavoring PR #15](https://github.com/McTalian-WoW-Addons/Endeavoring/pull/15) — all 5 workflows now use reusable callers ✅
+- [RPGLootFeed PR #528](https://github.com/McTalian-WoW-Addons/RPGLootFeed/pull/528) — all 5 workflows now use reusable callers + backported post-pkg-comment.cjs ✅
 
 **wow-build-tools PR:** `feat/reusable-workflows` — needs merge to beta, then update `v1-beta` tag
-
-#### Remaining
-
-4. `ci.yml` / `main.yml` (parameterized with addon name, Lua version, i18n toggle)
-5. `pr-checks.yml` (parameterized, needs `post-pkg-comment.cjs` consolidation first)
 
 ### Phase 5: Consolidate Scripts & Config
 
 Not started. Key items:
 
-- **`post-pkg-comment.cjs`** — Endeavoring version is more robust; backport to RPGLootFeed, then move to wow-build-tools
+- **`post-pkg-comment.cjs`** — ~~Endeavoring version is more robust; backport to RPGLootFeed, then move to wow-build-tools~~ Backported ✅. Still lives in each repo; can be moved to wow-build-tools later.
 - **Identical files to share:** `commitlint.config.js`, `.releaserc.json`
 - **Align `.nvmrc`** (`v24` vs `24.10.0`)
 - **Align Lua version** (Endeavoring CI: 5.4, RPGLootFeed CI: 5.3 — both rockspecs say `>= 5.3`)

--- a/future-improvements.md
+++ b/future-improvements.md
@@ -1,3 +1,5 @@
+# Future Improvements
+
 Pre-Release Checklist
 Purpose: Comprehensive pre-release validation
 When to use: Before tagging a version or releasing to CurseForge


### PR DESCRIPTION
## Summary

Add 5 reusable GitHub Actions workflows for WoW addon repos:

### Workflows Added
1. **`cleanup-stale-issues.yml`** — Standardized stale issue/PR management (zero inputs)
2. **`toc-updater.yml`** — Automated TOC interface version updates (inputs: `addon-name`, `pr-body`)
3. **`package-and-distribute.yml`** — Release packaging and Discord announcements (inputs: `addon-name`, `avatar-url`). Distribution links parsed dynamically from `.toc` file (`X-Curse-Project-ID`, `X-WoWI-ID`, `X-Wago-ID`)
4. **`ci.yml`** — CI pipeline: Lua tests, optional i18n checks, semantic-release (inputs: `addon-name`, `rockspec-name`, `lua-version`, `i18n-enabled`)
5. **`pr-checks.yml`** — PR validation: tests, translations, test packaging with PR comment, trunk linting, commitlint (inputs: `addon-name`, `rockspec-name`, `lua-version`, `i18n-enabled`, `trunk-enabled`)

### Rationale
- External addon devs can leverage the same workflows
- Versioned tags (`@v1-beta`) for stable pinning vs `.github`'s `@main`
- Phase 6 scaffolding alignment (`wow-build-tools init` can generate callers)

### Merge Order
1. Merge this PR to beta
2. Update `v1-beta` tag to new beta HEAD
3. Merge addon PRs: [Endeavoring #15](https://github.com/McTalian-WoW-Addons/Endeavoring/pull/15), [RPGLootFeed #528](https://github.com/McTalian-WoW-Addons/RPGLootFeed/pull/528)

Part of the org migration (Phase 4).