### PR TITLE
fix: toc-updater permissions and distro archive folder wrapping

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -251,8 +251,10 @@ jobs:
           echo "## Notes: This is NOT an addon, but a tool for building and releasing WoW addons." >> bin/${{ env.CMD }}.toc
           echo "## Author: McTalian" >> bin/${{ env.CMD }}.toc
           echo "" >> bin/${{ env.CMD }}.toc
-          echo "Putting it all in a zip"
-          zip -j ./${{ env.CMD }}-${{ env.VERSION }}.zip ./bin/${{ env.CMD }}_windows_amd64.zip ./bin/README.txt ./bin/LICENSE ./bin/${{ env.CMD }}.toc
+          echo "Putting it all in a zip (wrapped in ${{ env.CMD }}/ folder for CurseForge)"
+          mkdir -p ./${{ env.CMD }}
+          cp ./bin/${{ env.CMD }}_windows_amd64.zip ./bin/README.txt ./bin/LICENSE ./bin/${{ env.CMD }}.toc ./${{ env.CMD }}/
+          cd . && zip -r ./${{ env.CMD }}-${{ env.VERSION }}.zip ./${{ env.CMD }}/
 
       - name: Download binary
         uses: actions/download-artifact@v7

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -24,13 +24,14 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Clone project
         uses: actions/checkout@v4


### PR DESCRIPTION
Two fixes on this branch:

**1. Move toc-updater permissions to job level**

Workflow-level `permissions` on a reusable workflow conflict with callers that set `permissions: {}` at the workflow level, causing `startup_failure` with:
```
The workflow is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: none, pull-requests: none'.
```
Moved to job level, consistent with the other reusable workflows.

**2. Wrap distro archive contents in `wow-build-tools/` folder**

`zip -j` was placing all files at the root of the archive. CurseForge expects a top-level folder inside the zip (matching the addon/tool name). Files are now staged into a `wow-build-tools/` subdirectory before zipping.