### PR TITLE
fix: relax commitlint header-max-length to 150 chars

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,7 @@
 export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
+    "header-max-length": [2, "always", 150],
     "type-enum": [
       2,
       "always",


### PR DESCRIPTION
The default `@commitlint/config-conventional` enforces a 100-char header limit, but Dependabot PR titles for reusable workflow updates can exceed this (e.g. `build(deps): bump McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml from 1.pre.beta to 1.0.0` is ~103 chars).

This relaxes the limit to 150 chars so that Dependabot PRs pass commitlint without needing to customize the Dependabot commit message prefix.