### PR TITLE
refactor: migrate to angular preset + add release notes test

### DIFF
--- a/.github/workflows/wbt-pr.yml
+++ b/.github/workflows/wbt-pr.yml
@@ -23,6 +23,26 @@ jobs:
       - name: Trunk Code Quality
         uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1.3.1
 
+  test-release-notes:
+    name: Test Release Notes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: volta-cli/action@615a78f6c83e116339c53b94f3f82b4d6c0b7d18 # v5.0.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run release notes test
+        run: npm run test:release-notes
+
   test:
     runs-on: ubuntu-latest
     permissions:
@@ -108,7 +128,7 @@ jobs:
     name: Passing PR Checks
     runs-on: ubuntu-latest
     if: always()
-    needs: [trunk-check, test]
+    needs: [trunk-check, test, test-release-notes]
     steps:
       - name: Export needs results as JSON
         id: export-needs

--- a/.releaserc
+++ b/.releaserc
@@ -4,13 +4,13 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits"
+        "preset": "angular"
       }
     ],
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits",
+        "preset": "angular",
         "presetConfig": {
           "types": [
             { "type": "feat", "section": "✨ Features" },
@@ -29,5 +29,5 @@
     ],
     "@semantic-release/github"
   ],
-  "preset": "conventionalcommits"
+  "preset": "angular"
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,7 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits",
+        "preset": "angular",
         "releaseRules": [
           { "type": "locale", "release": "patch" },
           { "type": "toc", "release": "patch" }
@@ -14,25 +14,19 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits",
+        "preset": "angular",
         "presetConfig": {
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🪲 Bug Fixes" },
             { "type": "perf", "section": "⚡ Performance" },
-            {
-              "type": "locale",
-              "section": "🌏 i18n Translations"
-            },
-            {
-              "type": "toc",
-              "section": "📋 TOC Version Changes"
-            }
+            { "type": "locale", "section": "🌏 i18n Translations" },
+            { "type": "toc", "section": "📋 TOC Version Changes" }
           ]
         }
       }
     ],
     "@semantic-release/github"
   ],
-  "preset": "conventionalcommits"
+  "preset": "angular"
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,5 @@
 export default {
-  extends: ["@commitlint/config-conventional"],
+  extends: ["@commitlint/config-angular"],
   rules: {
     "header-max-length": [2, "always", 150],
     "type-enum": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,12 @@
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "21.2.1",
-        "@commitlint/config-conventional": "21.2.0",
+        "@commitlint/config-angular": "21.2.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "13.0.1",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "12.0.9",
         "@semantic-release/release-notes-generator": "14.1.1",
-        "conventional-changelog-conventionalcommits": "9.3.1",
         "semantic-release": "25.0.5"
       }
     },
@@ -109,6 +108,29 @@
       "bin": {
         "commitlint": "cli.js"
       },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-angular": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-21.2.0.tgz",
+      "integrity": "sha512-0h/gUnNnrpouI5F5yEx6g/NwPmQ8MujiHuMv2F9/UXvoKrhm9FmSP/M1Bss7HyyC5hDKVHgx61Il6WsCKBzy2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-angular-type-enum": "^21.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-angular-type-enum": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-21.0.1.tgz",
+      "integrity": "sha512-xTQlgHTaQyXfFpPI3w2dI7ppuTDWmF++1W/kgNohRpxhBzAoJxc6Q/2P7EjvJodtVl7+38xHyu0STtV4ERXdhg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=22.12.0"
       }
@@ -279,19 +301,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
-      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@commitlint/parse/node_modules/conventional-commits-parser": {
@@ -763,6 +772,19 @@
         "semantic-release": ">=20.1.0"
       }
     },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@semantic-release/error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -1129,6 +1151,19 @@
         "semantic-release": ">=20.1.0"
       }
     },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
@@ -1340,7 +1375,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
@@ -1616,6 +1652,7 @@
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
       "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
@@ -1633,29 +1670,16 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
-      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-writer": {
@@ -1854,6 +1878,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -2545,6 +2570,7 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,12 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
-    "@commitlint/config-conventional": "21.2.0",
+    "@commitlint/config-angular": "21.2.0",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "12.0.9",
     "@semantic-release/release-notes-generator": "14.1.1",
-    "conventional-changelog-conventionalcommits": "9.3.1",
     "semantic-release": "25.0.5"
   },
   "overrides": {
@@ -21,5 +20,8 @@
   "volta": {
     "node": "24.18.0",
     "npm": "11.18.0"
+  },
+  "scripts": {
+    "test:release-notes": "node tests/test-release-notes.mjs"
   }
 }

--- a/tests/test-release-notes.mjs
+++ b/tests/test-release-notes.mjs
@@ -1,0 +1,70 @@
+import { generateNotes } from "@semantic-release/release-notes-generator";
+
+const pluginConfig = {
+  preset: "angular",
+  presetConfig: {
+    types: [
+      { type: "feat", section: "Features" },
+      { type: "fix", section: "Bug Fixes" },
+      { type: "perf", section: "Performance Improvements" },
+      { type: "locale", section: "i18n Translations" },
+      { type: "toc", section: "TOC Version Changes" },
+    ],
+  },
+};
+
+const context = {
+  commits: [
+    { hash: "abc123", message: "feat: test feature for release notes" },
+    { hash: "def456", message: "fix: test bug fix for release notes" },
+    { hash: "ghi789", message: "perf: test performance improvement" },
+    { hash: "jkl012", message: "locale: update translations" },
+    { hash: "mno345", message: "toc: bump interface version" },
+  ],
+  lastRelease: { version: "1.2.2", gitTag: "v1.2.2", gitHead: "parent123" },
+  nextRelease: { version: "1.3.0", gitTag: "v1.3.0", gitHead: "head456" },
+  options: {
+    repositoryUrl: "https://github.com/McTalian-WoW-Addons/wow-build-tools",
+  },
+  cwd: process.cwd(),
+};
+
+const notes = await generateNotes(pluginConfig, context);
+console.log("Generated notes:");
+console.log(notes);
+console.log("\n--- Validation ---");
+
+const errors = [];
+if (!notes.trim()) errors.push("Notes are empty");
+if (!notes.includes("https://github.com/")) errors.push("Missing compare URL");
+
+const expectedSections = [
+  "Features",
+  "Bug Fixes",
+  "Performance Improvements",
+  "i18n Translations",
+  "TOC Version Changes",
+];
+
+const foundSections = expectedSections.filter((s) =>
+  notes.includes(`### ${s}`),
+);
+console.log(`Found sections: ${foundSections.join(", ")}`);
+
+if (foundSections.length === 0) {
+  errors.push("No expected sections found");
+}
+
+// Check version header format (angular uses #)
+console.log("First 100 chars:", JSON.stringify(notes.substring(0, 100)));
+if (!notes.match(/# \[\d+\.\d+\.\d+\]/)) {
+  errors.push("Missing version header (# [version])");
+}
+
+if (errors.length > 0) {
+  console.error("\n❌ Validation failed:");
+  errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}
+
+console.log("\n✅ Release notes validation passed");


### PR DESCRIPTION
- Switch commit-analyzer & release-notes-generator to angular preset
- Replace commitlint config-conventional with config-angular
- Add unit test validating release notes sections/format
- Wire test into PR workflow (test-release-notes job)